### PR TITLE
fix: replace unknown import.meta.env lookups with full env object

### DIFF
--- a/packages/babel-plugin-transform-vite-meta-env/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-transform-vite-meta-env/src/__tests__/__snapshots__/index.ts.snap
@@ -1,6 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`vite-meta-env not import.meta lookup: not import.meta lookup 1`] = `
+
+const x = import.meta()
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = import.meta()
+
+
+`;
+
 exports[`vite-meta-env not import.meta.env: not import.meta.env 1`] = `
+
+const x = import.meta.other
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = import.meta.other
+
+
+`;
+
+exports[`vite-meta-env not import.meta: not import.meta 1`] = `
 
 const x = process.env.MODE
 

--- a/packages/babel-plugin-transform-vite-meta-env/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-transform-vite-meta-env/src/__tests__/__snapshots__/index.ts.snap
@@ -17,7 +17,14 @@ const x = import.meta.env.OTHER
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const x = undefined
+const x = {
+  ...Object.fromEntries(Object.entries(process.env).filter(([k]) => /^VITE_/.test(k))),
+  NODE_ENV: process.env.NODE_ENV || 'test',
+  MODE: process.env.NODE_ENV || 'test',
+  BASE_URL: '/',
+  DEV: process.env.NODE_ENV !== 'production',
+  PROD: process.env.NODE_ENV === 'production'
+}.OTHER
 
 
 `;
@@ -84,6 +91,61 @@ const x = import.meta.env.VITE_VAR
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const x = process.env.VITE_VAR
+
+
+`;
+
+exports[`vite-meta-env replace env object: replace env object 1`] = `
+
+const env = import.meta.env
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const env = {
+  ...Object.fromEntries(Object.entries(process.env).filter(([k]) => /^VITE_/.test(k))),
+  NODE_ENV: process.env.NODE_ENV || 'test',
+  MODE: process.env.NODE_ENV || 'test',
+  BASE_URL: '/',
+  DEV: process.env.NODE_ENV !== 'production',
+  PROD: process.env.NODE_ENV === 'production'
+}
+
+
+`;
+
+exports[`vite-meta-env replace key access: replace key access 1`] = `
+
+const key = "VITE_VAR"; const x = import.meta.env[key]
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const key = 'VITE_VAR'
+const x = {
+  ...Object.fromEntries(Object.entries(process.env).filter(([k]) => /^VITE_/.test(k))),
+  NODE_ENV: process.env.NODE_ENV || 'test',
+  MODE: process.env.NODE_ENV || 'test',
+  BASE_URL: '/',
+  DEV: process.env.NODE_ENV !== 'production',
+  PROD: process.env.NODE_ENV === 'production'
+}[key]
+
+
+`;
+
+exports[`vite-meta-env replace string access: replace string access 1`] = `
+
+const x = import.meta.env["VITE_VAR"]
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = {
+  ...Object.fromEntries(Object.entries(process.env).filter(([k]) => /^VITE_/.test(k))),
+  NODE_ENV: process.env.NODE_ENV || 'test',
+  MODE: process.env.NODE_ENV || 'test',
+  BASE_URL: '/',
+  DEV: process.env.NODE_ENV !== 'production',
+  PROD: process.env.NODE_ENV === 'production'
+}['VITE_VAR']
 
 
 `;

--- a/packages/babel-plugin-transform-vite-meta-env/src/__tests__/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-env/src/__tests__/index.ts
@@ -12,6 +12,9 @@ pluginTester({
     'replace DEV': 'const x = import.meta.env.DEV',
     'replace PROD': 'const x = import.meta.env.PROD',
     'replace VITE_* variables': 'const x = import.meta.env.VITE_VAR',
+    'replace string access': 'const x = import.meta.env["VITE_VAR"]',
+    'replace key access': 'const key = "VITE_VAR"; const x = import.meta.env[key]',
+    'replace env object': 'const env = import.meta.env',
     'not replaceable': 'const x = import.meta.env.OTHER',
     'not import.meta.env': 'const x = process.env.MODE'
   }

--- a/packages/babel-plugin-transform-vite-meta-env/src/__tests__/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-env/src/__tests__/index.ts
@@ -16,6 +16,8 @@ pluginTester({
     'replace key access': 'const key = "VITE_VAR"; const x = import.meta.env[key]',
     'replace env object': 'const env = import.meta.env',
     'not replaceable': 'const x = import.meta.env.OTHER',
-    'not import.meta.env': 'const x = process.env.MODE'
+    'not import.meta.env': 'const x = import.meta.other',
+    'not import.meta': 'const x = process.env.MODE',
+    'not import.meta lookup': 'const x = import.meta()'
   }
 })

--- a/packages/babel-plugin-transform-vite-meta-env/src/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-env/src/index.ts
@@ -75,6 +75,18 @@ export default function viteMetaEnvBabelPlugin({
         }
       },
       MetaProperty(path) {
+        const envNode = t.isMemberExpression(path.parentPath.node) && path.parentPath.node
+
+        if (!envNode) {
+          return
+        }
+
+        const isEnvVar = t.isIdentifier(envNode.property) && envNode.property.name === 'env'
+
+        if (!isEnvVar) {
+          return
+        }
+
         path.parentPath.replaceWith(replaceEnv(template))
       }
     }


### PR DESCRIPTION
Fixes #1

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Replaces unknown usages of `import.meta.env` with the full env object.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

<!-- Why are these changes necessary? -->

Despite [what the docs say](https://vitejs.dev/guide/env-and-mode.html#production-replacement), the following usages of `import.meta.env` will work in both dev and production:

```js
const env = import.meta.env

const viteVar = import.meta.env["VITE_VAR"]

const some key = "VITE_VAR"
const someVar = import.meta.env[someKey]

const otherVar = import.meta.env.OTHER // note that while it does replace this, it won't resolve to an environment variable and will ultimately be `undefined`
```

**How**:

<!-- How were these changes implemented? -->

After we replace known/allowed keys, a second visitor replaces any remaining references of `import.meta.env` with an object of all the built in vars and a filtered set of `process.env` vars (only those starting with "VITE_").

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
