### PR TITLE
Add support for eager via the `{ eager: true }` argument to `import.meta.glob`

### DIFF
--- a/packages/babel-plugin-transform-vite-meta-glob/README.md
+++ b/packages/babel-plugin-transform-vite-meta-glob/README.md
@@ -29,7 +29,11 @@
 ```js
 const modules = import.meta.glob('./path/to/files/**/*')
 
-const eagerModules = import.meta.globEager('./path/to/files/**/*')
+// eager
+const eagerModules = import.meta.glob('./path/to/files/**/*', { eager: true })
+
+// deprecated eager
+const deprecatedEagerModules = import.meta.globEager('./path/to/files/**/*')
 ```
 
 **Out**
@@ -44,7 +48,18 @@ const modules = {
   './path/to/files/file3.js': () => import(('./path/to/files/file3.js')
 }
 
-const eagerModules = {
+// eager
+import * as __glob__0_0 from './path/to/files/file1.js'
+import * as __glob__0_1 from './path/to/files/file2.js'
+import * as __glob__0_2 from './path/to/files/file3.js'
+const eagerModules =  {
+  './path/to/files/file1.js': __glob__0_1,
+  './path/to/files/file2.js': __glob__0_2,
+  './path/to/files/file3.js': __glob__0_3
+}
+
+// deprecated eager
+const deprecatedEagerModules = {
   './path/to/files/file1.js': require('./path/to/files/file1.js'),
   './path/to/files/file2.js': require('./path/to/files/file2.js'),
   './path/to/files/file3.js': require('./path/to/files/file3.js')

--- a/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/__snapshots__/index.ts.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`vite-meta-glob glob all files eagerly, with { eager: true }: glob all files eagerly, with { eager: true } 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/*", { eager: true })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import * as __glob__0_0 from './fixtures/file1.ts'
+import * as __glob__0_1 from './fixtures/file2.ts'
+import * as __glob__0_2 from './fixtures/file3.ts'
+const modules = {
+  './fixtures/file1.ts': __glob__0_0,
+  './fixtures/file2.ts': __glob__0_1,
+  './fixtures/file3.ts': __glob__0_2
+}
+
+
+`;
+
 exports[`vite-meta-glob glob all files eagerly: glob all files eagerly 1`] = `
 
 const modules = import.meta.globEager("./fixtures/**/*")
@@ -10,6 +28,21 @@ const modules = {
   './fixtures/file1.ts': require('./fixtures/file1.ts'),
   './fixtures/file2.ts': require('./fixtures/file2.ts'),
   './fixtures/file3.ts': require('./fixtures/file3.ts')
+}
+
+
+`;
+
+exports[`vite-meta-glob glob all files normally, with { eager: false }: glob all files normally, with { eager: false } 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/*", { eager: false })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = {
+  './fixtures/file1.ts': () => import('./fixtures/file1.ts'),
+  './fixtures/file2.ts': () => import('./fixtures/file2.ts'),
+  './fixtures/file3.ts': () => import('./fixtures/file3.ts')
 }
 
 
@@ -30,9 +63,31 @@ const modules = {
 
 `;
 
+exports[`vite-meta-glob glob no files eagerly, with { eager: true }: glob no files eagerly, with { eager: true } 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/not-found", { eager: true })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = {}
+
+
+`;
+
 exports[`vite-meta-glob glob no files eagerly: glob no files eagerly 1`] = `
 
 const modules = import.meta.globEager("./fixtures/**/not-found")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = {}
+
+
+`;
+
+exports[`vite-meta-glob glob no files normally, with { eager: false }: glob no files normally, with { eager: false } 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/not-found", { eager: false })
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -52,6 +107,22 @@ const modules = {}
 
 `;
 
+exports[`vite-meta-glob glob some files eagerly, with { eager: true }: glob some files eagerly, with { eager: true } 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/*{1,3}*", { eager: true })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import * as __glob__0_0 from './fixtures/file1.ts'
+import * as __glob__0_1 from './fixtures/file3.ts'
+const modules = {
+  './fixtures/file1.ts': __glob__0_0,
+  './fixtures/file3.ts': __glob__0_1
+}
+
+
+`;
+
 exports[`vite-meta-glob glob some files eagerly: glob some files eagerly 1`] = `
 
 const modules = import.meta.globEager("./fixtures/**/*{1,3}*")
@@ -61,6 +132,20 @@ const modules = import.meta.globEager("./fixtures/**/*{1,3}*")
 const modules = {
   './fixtures/file1.ts': require('./fixtures/file1.ts'),
   './fixtures/file3.ts': require('./fixtures/file3.ts')
+}
+
+
+`;
+
+exports[`vite-meta-glob glob some files normally, with { eager: false }: glob some files normally, with { eager: false } 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/*{1,3}*", { eager: false })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = {
+  './fixtures/file1.ts': () => import('./fixtures/file1.ts'),
+  './fixtures/file3.ts': () => import('./fixtures/file3.ts')
 }
 
 
@@ -80,6 +165,56 @@ const modules = {
 
 `;
 
+exports[`vite-meta-glob glob with non-boolean eager option: glob with non-boolean eager option 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/*", { eager: 11 })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = import.meta.glob('./fixtures/**/*', {
+  eager: 11
+})
+
+
+`;
+
+exports[`vite-meta-glob glob with non-object options: glob with non-object options 1`] = `
+
+const modules = import.meta.glob("./fixtures/**/*", true)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = import.meta.glob('./fixtures/**/*', true)
+
+
+`;
+
+exports[`vite-meta-glob no filename, with { eager: false }: no filename, with { eager: false } 1`] = `
+
+import.meta.glob("./fixtures/**/*", { eager: false })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import.meta.glob('./fixtures/**/*', {
+  eager: false
+})
+
+
+`;
+
+exports[`vite-meta-glob no filename, with { eager: true }: no filename, with { eager: true } 1`] = `
+
+import.meta.glob("./fixtures/**/*", { eager: true })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import.meta.glob('./fixtures/**/*', {
+  eager: true
+})
+
+
+`;
+
 exports[`vite-meta-glob no filename: no filename 1`] = `
 
 import.meta.glob("./fixtures/**/*")
@@ -87,6 +222,32 @@ import.meta.glob("./fixtures/**/*")
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import.meta.glob('./fixtures/**/*')
+
+
+`;
+
+exports[`vite-meta-glob not a string arg, with { eager: false }: not a string arg, with { eager: false } 1`] = `
+
+const modules = import.meta.glob(12, { eager: false })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = import.meta.glob(12, {
+  eager: false
+})
+
+
+`;
+
+exports[`vite-meta-glob not a string arg, with { eager: true }: not a string arg, with { eager: true } 1`] = `
+
+const modules = import.meta.glob(12, { eager: true })
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const modules = import.meta.glob(12, {
+  eager: true
+})
 
 
 `;

--- a/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/index.ts
@@ -31,6 +31,36 @@ pluginTester({
     'not import.meta.globEager': withFileName('globEager("./fixtures/**/*")'),
     'not a string arg': withFileName('globEager(1)'),
     'too many args': withFileName('globEager("./fixtures/**/*1*", "./fixtures/**/*2*")'),
-    'no filename': 'import.meta.glob("./fixtures/**/*")'
+    'no filename': 'import.meta.glob("./fixtures/**/*")',
+    // ImportGlobOptions test cases
+    'glob all files eagerly, with { eager: true }': withFileName(
+      'const modules = import.meta.glob("./fixtures/**/*", { eager: true })'
+    ),
+    'glob some files eagerly, with { eager: true }': withFileName(
+      'const modules = import.meta.glob("./fixtures/**/*{1,3}*", { eager: true })'
+    ),
+    'glob no files eagerly, with { eager: true }': withFileName(
+      'const modules = import.meta.glob("./fixtures/**/not-found", { eager: true })'
+    ),
+    'glob all files normally, with { eager: false }': withFileName(
+      'const modules = import.meta.glob("./fixtures/**/*", { eager: false })'
+    ),
+    'glob some files normally, with { eager: false }': withFileName(
+      'const modules = import.meta.glob("./fixtures/**/*{1,3}*", { eager: false })'
+    ),
+    'glob no files normally, with { eager: false }': withFileName(
+      'const modules = import.meta.glob("./fixtures/**/not-found", { eager: false })'
+    ),
+    'glob with non-object options': 'const modules = import.meta.glob("./fixtures/**/*", true)',
+    'glob with non-boolean eager option':
+      'const modules = import.meta.glob("./fixtures/**/*", { eager: 11 })',
+    'not a string arg, with { eager: true }': withFileName(
+      'const modules = import.meta.glob(12, { eager: true })'
+    ),
+    'not a string arg, with { eager: false }': withFileName(
+      'const modules = import.meta.glob(12, { eager: false })'
+    ),
+    'no filename, with { eager: true }': 'import.meta.glob("./fixtures/**/*", { eager: true })',
+    'no filename, with { eager: false }': 'import.meta.glob("./fixtures/**/*", { eager: false })'
   }
 })

--- a/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
@@ -52,6 +52,77 @@ export default function viteMetaGlobBabelPlugin({
 
           path.replaceWith(replacement)
         }
+      },
+      VariableDeclaration(path, state) {
+        const id = path.node.declarations[0].id
+        const call = path.node.declarations[0].init
+        const callee = t.isCallExpression(call) && t.isMemberExpression(call.callee) && call.callee
+        const identifier = t.isIdentifier(id) && t.identifier(id.name)
+
+        if (!identifier || !callee) {
+          return
+        }
+
+        const args = call.arguments
+        const sourceFile = state.file.opts.filename
+        const propertyName = t.isIdentifier(callee.property) && callee.property.name
+        const eagerOption =
+          t.isObjectExpression(args[1]) &&
+          args[1].properties.filter(
+            (p) => t.isObjectProperty(p) && t.isIdentifier(p.key) && p.key.name === 'eager'
+          )
+
+        if (!sourceFile || !propertyName || !eagerOption || eagerOption.length === 0) {
+          return
+        }
+
+        if (
+          isGlobKey(propertyName) &&
+          t.isMetaProperty(callee.object) &&
+          args.length === 2 &&
+          t.isStringLiteral(args[0]) &&
+          t.isObjectProperty(eagerOption[0]) &&
+          t.isBooleanLiteral(eagerOption[0].value)
+        ) {
+          const cwd = nodePath.dirname(sourceFile)
+          const globPaths = glob.sync(args[0].value, { cwd })
+
+          if (eagerOption[0].value.value) {
+            const identifiers = globPaths.map((_, idx) => t.identifier(`__glob__0_${idx}`))
+
+            const imports = globPaths.map((globPath, idx) => {
+              const specifier = t.importNamespaceSpecifier(identifiers[idx])
+              const modulePath = t.stringLiteral(globPath)
+              return t.importDeclaration([specifier], modulePath)
+            })
+
+            const variable = t.variableDeclaration('const', [
+              t.variableDeclarator(
+                identifier,
+                t.objectExpression(
+                  globPaths.map((globPath, idx) =>
+                    t.objectProperty(t.stringLiteral(globPath), identifiers[idx])
+                  )
+                )
+              )
+            ])
+
+            path.replaceWithMultiple([...imports, variable])
+          } else {
+            const replacement = t.variableDeclaration('const', [
+              t.variableDeclarator(
+                identifier,
+                t.objectExpression(
+                  globPaths.map((globPath) =>
+                    t.objectProperty(t.stringLiteral(globPath), asts[propertyName](globPath))
+                  )
+                )
+              )
+            ])
+
+            path.replaceWith(replacement)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
**🙋🏽 Question**

I've targeted the code as specified at https://vitejs.dev/guide/features.html#glob-import, but realise that that might not be what's needed in a Node env, can someone confirm? Should the code produced actually use `require()`?

**What**:

Addresses https://github.com/OpenSourceRaidGuild/babel-vite/issues/42

Adds support for specifying eager import via the `ImportGlobOptions` argument to `import.meta.glob`

**Why**:

`import.meta.globEager` is deprecated in favour of the options argument. Without support in this plugin, Babel (and therefore Jest) is unable to understand this syntax.

**How**:

The target for what this should produce was obtained from [the Vite docs on Glob Imports](https://vitejs.dev/guide/features.html#glob-import). Specifically, 

> If you'd rather import all the modules directly (e.g. relying on side-effects in these modules to be applied first), you can pass `{ eager: true }` as the second argument:
>
> ```js
> const modules = import.meta.glob('./dir/*.js', { eager: true })
> ```
> The above will be transformed into the following:
>
> ```js
> // code produced by vite
> import * as __glob__0_0 from './dir/foo.js'
> import * as __glob__0_1 from './dir/bar.js'
> const modules = {
>   './dir/foo.js': __glob__0_0,
>   './dir/bar.js': __glob__0_1,
> }
> ```

A new visitor is added to target the entire `VariableDeclaration`, and it is replaced with the specified code above.

**Checklist**:

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table - _the `npm run contributors:add` command is not available, and I didn't want to manually modify the contributors sections, seeing as it says not to 🙃_ 
