### PR TITLE
chore(tools): set workspaces-update to false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
 legacy-peer-deps=true
+workspaces-update=false


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

An attempt to fix the `multi-sematic-release` publishing.

**Why**:

I found a [note in their README](https://github.com/dhoulb/multi-semantic-release?tab=readme-ov-file#npm-v85-npm-err-notarget-no-matching-version-found-for) about setting this setting to `false` as a workaround for the `notarget` error we are seeing now.

