### PR TITLE
Add support for eager via the { eager: true } argument to import.meta.glob in Jest

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,7 +71,7 @@ jobs:
         run: npm run build
 
       - name: 🚀 Release
-        run: npx multi-semantic-release
+        run: npx multi-semantic-release --sequential-init	--sequential-prepare
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,7 +71,7 @@ jobs:
         run: npm run build
 
       - name: 🚀 Release
-        run: npx multi-semantic-release --sequential-init	--sequential-prepare
+        run: npx multi-semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/__snapshots__/index.ts.snap
@@ -6,9 +6,9 @@ const modules = import.meta.glob("./fixtures/**/*", { eager: true })
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import * as __glob__0_0 from './fixtures/file1.ts'
-import * as __glob__0_1 from './fixtures/file2.ts'
-import * as __glob__0_2 from './fixtures/file3.ts'
+const __glob__0_0 = require('./fixtures/file1.ts')
+const __glob__0_1 = require('./fixtures/file2.ts')
+const __glob__0_2 = require('./fixtures/file3.ts')
 const modules = {
   './fixtures/file1.ts': __glob__0_0,
   './fixtures/file2.ts': __glob__0_1,
@@ -113,8 +113,8 @@ const modules = import.meta.glob("./fixtures/**/*{1,3}*", { eager: true })
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import * as __glob__0_0 from './fixtures/file1.ts'
-import * as __glob__0_1 from './fixtures/file3.ts'
+const __glob__0_0 = require('./fixtures/file1.ts')
+const __glob__0_1 = require('./fixtures/file3.ts')
 const modules = {
   './fixtures/file1.ts': __glob__0_0,
   './fixtures/file3.ts': __glob__0_1

--- a/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
@@ -91,9 +91,15 @@ export default function viteMetaGlobBabelPlugin({
             const identifiers = globPaths.map((_, idx) => t.identifier(`__glob__0_${idx}`))
 
             const imports = globPaths.map((globPath, idx) => {
-              const specifier = t.importNamespaceSpecifier(identifiers[idx])
+              // const specifier = t.importNamespaceSpecifier(identifiers[idx])
               const modulePath = t.stringLiteral(globPath)
-              return t.importDeclaration([specifier], modulePath)
+              // return t.importDeclaration([specifier], modulePath)
+              return t.variableDeclaration('const', [
+                t.variableDeclarator(
+                  identifiers[idx],
+                  t.callExpression(t.identifier('require'), [modulePath])
+                )
+              ]);
             })
 
             const variable = t.variableDeclaration('const', [

--- a/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
@@ -91,9 +91,7 @@ export default function viteMetaGlobBabelPlugin({
             const identifiers = globPaths.map((_, idx) => t.identifier(`__glob__0_${idx}`))
 
             const imports = globPaths.map((globPath, idx) => {
-              // const specifier = t.importNamespaceSpecifier(identifiers[idx])
               const modulePath = t.stringLiteral(globPath)
-              // return t.importDeclaration([specifier], modulePath)
               return t.variableDeclaration('const', [
                 t.variableDeclarator(
                   identifiers[idx],


### PR DESCRIPTION
**What**:

Addresses https://github.com/OpenSourceRaidGuild/babel-vite/issues/42, and https://github.com/OpenSourceRaidGuild/babel-vite/pull/43#issuecomment-1869208565

**Why**:
import.meta.globEager is deprecated, use import.meta.glob instead.
But the previous method was use `import declarative` so it's make Jest failure at `import * as glob__glob__`
<img width="761" alt="image" src="https://github.com/OpenSourceRaidGuild/babel-vite/assets/30227910/4ca9edc2-a402-47be-aba2-46d3ec1a04a9">


**How**:
Change `import statement` to require as the implement stuffs in globEager
```

const modules = import.meta.globEager("./fixtures/**/*")

      ↓ ↓ ↓ ↓ ↓ ↓

const modules = {
  './fixtures/file1.ts': require('./fixtures/file1.ts'),
  './fixtures/file2.ts': require('./fixtures/file2.ts'),
  './fixtures/file3.ts': require('./fixtures/file3.ts')
}
```
then result is 
```

const __glob__0_0 = require('./fixtures/file1.ts')
const __glob__0_1 = require('./fixtures/file2.ts')
const __glob__0_2 = require('./fixtures/file3.ts')
const modules = {
  './fixtures/file1.ts': __glob__0_0,
  './fixtures/file2.ts': __glob__0_1,
  './fixtures/file3.ts': __glob__0_2
}

```

Also tested-well in my own repo, and everything is fine 
<img width="1257" alt="image" src="https://github.com/OpenSourceRaidGuild/babel-vite/assets/30227910/c12ed320-64eb-4272-9ac6-4b8e976fa23d">

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
