### PR TITLE
Fix "eager: true emits require (doesn't exist in browsers) instead of import"

### DIFF
--- a/packages/babel-plugin-transform-vite-meta-glob/README.md
+++ b/packages/babel-plugin-transform-vite-meta-glob/README.md
@@ -49,9 +49,9 @@ const modules = {
 }
 
 // eager
-import * as __glob__0_0 from './path/to/files/file1.js'
-import * as __glob__0_1 from './path/to/files/file2.js'
-import * as __glob__0_2 from './path/to/files/file3.js'
+import __glob__0_0 from './path/to/files/file1.js'
+import __glob__0_1 from './path/to/files/file2.js'
+import __glob__0_2 from './path/to/files/file3.js'
 const eagerModules =  {
   './path/to/files/file1.js': __glob__0_1,
   './path/to/files/file2.js': __glob__0_2,

--- a/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/__tests__/__snapshots__/index.ts.snap
@@ -6,9 +6,9 @@ const modules = import.meta.glob("./fixtures/**/*", { eager: true })
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const __glob__0_0 = require('./fixtures/file1.ts')
-const __glob__0_1 = require('./fixtures/file2.ts')
-const __glob__0_2 = require('./fixtures/file3.ts')
+import __glob__0_0 from './fixtures/file1.ts'
+import __glob__0_1 from './fixtures/file2.ts'
+import __glob__0_2 from './fixtures/file3.ts'
 const modules = {
   './fixtures/file1.ts': __glob__0_0,
   './fixtures/file2.ts': __glob__0_1,
@@ -113,8 +113,8 @@ const modules = import.meta.glob("./fixtures/**/*{1,3}*", { eager: true })
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const __glob__0_0 = require('./fixtures/file1.ts')
-const __glob__0_1 = require('./fixtures/file3.ts')
+import __glob__0_0 from './fixtures/file1.ts'
+import __glob__0_1 from './fixtures/file3.ts'
 const modules = {
   './fixtures/file1.ts': __glob__0_0,
   './fixtures/file3.ts': __glob__0_1

--- a/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
+++ b/packages/babel-plugin-transform-vite-meta-glob/src/index.ts
@@ -96,12 +96,7 @@ export default function viteMetaGlobBabelPlugin({
 
             const imports = globPaths.map((globPath, idx) => {
               const modulePath = t.stringLiteral(globPath)
-              return t.variableDeclaration('const', [
-                t.variableDeclarator(
-                  identifiers[idx],
-                  t.callExpression(t.identifier('require'), [modulePath])
-                )
-              ])
+              return t.importDeclaration([t.importDefaultSpecifier(identifiers[idx])], modulePath)
             })
 
             const variable = t.variableDeclaration('const', [


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Fixes https://github.com/OpenSourceRaidGuild/babel-vite/issues/57

**Why**:

We expect import to be used instead of require:

```js
const __glob__0_0 = require("./scenarios/baseline-handlebars-list.gjs");
const __glob__0_1 = require("./scenarios/baseline-inner-html.gjs");
const __glob__0_2 = require("./scenarios/ember-get.gjs");
const definedScenarios = {
  "./scenarios/baseline-handlebars-list.gjs": __glob__0_0,
  "./scenarios/baseline-inner-html.gjs": __glob__0_1,
  "./scenarios/ember-get.gjs": __glob__0_2
};
```

should be

```js
import __glob__0_0 from "./scenarios/baseline-handlebars-list.gjs";
import  __glob__0_1 from "./scenarios/baseline-inner-html.gjs";
import  __glob__0_2 from "./scenarios/ember-get.gjs";
const definedScenarios = {
  "./scenarios/baseline-handlebars-list.gjs": __glob__0_0,
  "./scenarios/baseline-inner-html.gjs": __glob__0_1,
  "./scenarios/ember-get.gjs": __glob__0_2
};
```

This is already listed in the documentation.

**How**:

Adapted the transformer and tests.

**Checklist**:

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [X] Documentation updated
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
